### PR TITLE
Update Elements interface

### DIFF
--- a/src/main/java/com/extsoft/comments/comments/Rows.java
+++ b/src/main/java/com/extsoft/comments/comments/Rows.java
@@ -1,12 +1,12 @@
 package com.extsoft.comments.comments;
 
+import com.extsoft.comments.elements.AllElements;
 import com.extsoft.comments.elements.DefaultElements;
+import com.extsoft.comments.elements.Element;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 final class Rows {
     private final WebDriver webDriver;
@@ -18,10 +18,18 @@ final class Rows {
     }
 
     Iterator<Row> rows() {
-        List<Row> rows = new ArrayList<>();
-        new DefaultElements(webDriver, by)
-                .instances()
-                .forEachRemaining(element -> rows.add(new Row(webDriver, element)));
-        return rows.iterator();
+        Iterator<Element> iterator = new DefaultElements(webDriver, by).find(new AllElements());
+        return new Iterator<Row>() {
+
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public Row next() {
+                return new Row(webDriver, iterator.next());
+            }
+        };
     }
 }

--- a/src/main/java/com/extsoft/comments/comments/SelfLoadedComments.java
+++ b/src/main/java/com/extsoft/comments/comments/SelfLoadedComments.java
@@ -21,13 +21,9 @@ public class SelfLoadedComments implements Comments {
 
     private void switchPage() {
         Elements elements = new DefaultElements(webDriver, By.cssSelector(".webgrid-footer a"));
-        Iterator<Element> instances = elements.instances();
-        while (instances.hasNext()) {
-            Button element = new DefaultButton(instances.next());
-            if (element.name().contains(page)) {
-                element.press();
-                break;
-            }
+        Iterator<Element> iterator = elements.find(new ContainsText(page));
+        if (iterator.hasNext()) {
+            new DefaultButton(iterator.next()).press();
         }
     }
 

--- a/src/main/java/com/extsoft/comments/elements/AllElements.java
+++ b/src/main/java/com/extsoft/comments/elements/AllElements.java
@@ -1,0 +1,8 @@
+package com.extsoft.comments.elements;
+
+public class AllElements implements Criteria {
+    @Override
+    public boolean relevant(Element element) {
+        return true;
+    }
+}

--- a/src/main/java/com/extsoft/comments/elements/ContainsText.java
+++ b/src/main/java/com/extsoft/comments/elements/ContainsText.java
@@ -1,0 +1,15 @@
+package com.extsoft.comments.elements;
+
+public class ContainsText implements Criteria {
+
+    private final String textToContain;
+
+    public ContainsText(String textToContain) {
+        this.textToContain = textToContain;
+    }
+
+    @Override
+    public boolean relevant(Element element) {
+        return element.getText().contains(textToContain);
+    }
+}

--- a/src/main/java/com/extsoft/comments/elements/Criteria.java
+++ b/src/main/java/com/extsoft/comments/elements/Criteria.java
@@ -1,0 +1,6 @@
+package com.extsoft.comments.elements;
+
+public interface Criteria {
+
+    boolean relevant(Element element);
+}

--- a/src/main/java/com/extsoft/comments/elements/DefaultElements.java
+++ b/src/main/java/com/extsoft/comments/elements/DefaultElements.java
@@ -17,14 +17,15 @@ public class DefaultElements implements Elements {
         this.elementsLocator = elementsLocator;
     }
 
-
     @Override
-    public Iterator<Element> instances() {
-        List<Element> elements = webDriver.findElements(elementsLocator)
+    public Iterator<Element> find(Criteria criteria) {
+        return instances().stream().filter(criteria::relevant).collect(Collectors.toList()).iterator();
+    }
+
+    private List<Element> instances() {
+        return webDriver.findElements(elementsLocator)
                 .stream()
                 .map(DefaultElement::new)
                 .collect(Collectors.toList());
-        return elements.iterator();
-
     }
 }

--- a/src/main/java/com/extsoft/comments/elements/Elements.java
+++ b/src/main/java/com/extsoft/comments/elements/Elements.java
@@ -1,8 +1,10 @@
 package com.extsoft.comments.elements;
 
+
 import java.util.Iterator;
 
 public interface Elements {
 
-    Iterator<Element> instances();
+    Iterator<Element> find(Criteria criteria);
+
 }


### PR DESCRIPTION
Elements interface provides only one method:
    Iterator<Element> find(Criteria criteria)

Add Criteria interface provides ability to get the relevant elements
from Elements interface.
Add two implementations of Criteria:
- ContainsText allows to filter elements by containing provided text.
- AllElements allows to return all found elements.

Make Rows.rows() lazy.